### PR TITLE
Fix compatibility with Lua 5.2+

### DIFF
--- a/bin/luacc.lua
+++ b/bin/luacc.lua
@@ -4,8 +4,9 @@
 ---------------------------------------------------------
 
 do
-    local origin_loader = package.loaders[2]
-    package.loaders[2] = function(path)
+    local searchers = package.searchers or package.loaders
+    local origin_seacher = searchers[2]
+    searchers[2] = function(path)
         local files =
         {
 ------------------------
@@ -1740,7 +1741,7 @@ end,
         if files[path] then
             return files[path]
         else
-            return origin_loader(path)
+            return origin_seacher(path)
         end
     end
 end
@@ -1769,8 +1770,9 @@ local data_loader_temp =
 ---------------------------------------------------------
 
 do
-    local origin_loader = package.loaders[2]
-    package.loaders[2] = function(path)
+    local searchers = package.searchers or package.loaders
+    local origin_seacher = searchers[2]
+    searchers[2] = function(path)
         local files =
         {
 ------------------------
@@ -1793,7 +1795,7 @@ end,
         if files[path] then
             return files[path]
         else
-            return origin_loader(path)
+            return origin_seacher(path)
         end
     end
 end

--- a/src/luacc.lua
+++ b/src/luacc.lua
@@ -21,8 +21,9 @@ local data_loader_temp =
 ---------------------------------------------------------
 
 do
-    local origin_loader = package.loaders[2]
-    package.loaders[2] = function(path)
+    local searchers = package.searchers or package.loaders
+    local origin_seacher = searchers[2]
+    searchers[2] = function(path)
         local files =
         {
 ------------------------
@@ -45,7 +46,7 @@ end,
         if files[path] then
             return files[path]
         else
-            return origin_loader(path)
+            return origin_seacher(path)
         end
     end
 end


### PR DESCRIPTION
Table package.loaders was renamed to package.searchers in Lua 5.2,
see https://www.lua.org/manual/5.2/manual.html#8.2.